### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "libfp16"
+description := "Header-only library for conversion to/from half-precision floating point formats."
+gitrepo     := "https://github.com/Maratyszcza/FP16.git"
+homepage    := "https://github.com/Maratyszcza/FP16/"
+version     := 0a92994 sha256:a91f4770ff9c39f4d72e339c379f566b3bbb359fa66122d85fc0bae3dde7abc7 https://github.com/Maratyszcza/FP16/archive/0a92994.tar.gz
+license     := "MIT"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

